### PR TITLE
Channel Association to Tag

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.getelevar.com"
 documentation: "https://github.com/getelevar/gtm-monitoring-core/blob/master/README.md"
 versions:
+  - sha: 827d5ced972d152af92543a22eb7297b4594f04a
+    changeNotes: Send one channel per tag name instead of sending only unique channels to support mapping channel to tag.
   - sha: 57aa9b910a701ff7406e4da2deb3a3d02423d979
     changeNotes: Add page url to pixel to fix issue with Safari ITP and encode pixel components.
   - sha: 77f158f61ea9ef5029e301ec041a93eba0b3504c

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,8 @@
 homepage: "https://www.getelevar.com"
 documentation: "https://github.com/getelevar/gtm-monitoring-core/blob/master/README.md"
 versions:
-  - sha: 827d5ced972d152af92543a22eb7297b4594f04a
-    changeNotes: Send one channel per tag name instead of sending only unique channels to support mapping channel to tag.
+  - sha: 090d13ce04e86c3b46d6971431beb9187675d1d8
+    changeNotes: Send one pixel per tag instead of one per variable error and add a version key to the pixel.
   - sha: 9c123ca92dce7853c9edae19542596d3b3214e5e
     changeNotes: Fix issue with component encoding throwing when the value being encoded is not a string by always providing a string.
   - sha: 57aa9b910a701ff7406e4da2deb3a3d02423d979


### PR DESCRIPTION
part of https://github.com/getelevar/elevar-monorepo/issues/119

Instead of sending only unique channels for an error, send a list of channels that can be mapped to the tags.

---

Channels will now be sent as a list of strings separated by commas where the order can be used to associate them to the tag names: `facebook,,snapchat,facebook,facebook`.

Blank values mean that no channel was specified for that tag.

I also added a test in the template to verify that a channel is sent for each tag_name or then it's blank.