### PR TITLE
Fix "encodeUriComponent" input

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.getelevar.com"
 documentation: "https://github.com/getelevar/gtm-monitoring-core/blob/master/README.md"
 versions:
+  - sha: 9c123ca92dce7853c9edae19542596d3b3214e5e
+    changeNotes: Fix issue with component encoding throwing when the value being encoded is not a string by always providing a string.
   - sha: 57aa9b910a701ff7406e4da2deb3a3d02423d979
     changeNotes: Add page url to pixel to fix issue with Safari ITP and encode pixel components.
   - sha: 77f158f61ea9ef5029e301ec041a93eba0b3504c

--- a/template.tpl
+++ b/template.tpl
@@ -20,7 +20,11 @@ ___INFO___
     "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABdCAYAAABafGNLAAAH6ElEQVR4Xu2dX2hbVRzHv78k1YGyP7gUhg92/n0QbJpOhKGuexARhTXYVEFkKU1Bn9btTRDXrVN8cvVtsIy1IEOWYSqswwdxLSj+YU1bH3xQZFbEuaa6RVTEpPnJSdOua5Pcc+7NuX/Se1/ykHN+55zv5/y75/zOuQSXPonuG9tbWortAEeYqA2MSCWr4ne7S7Otmq0pUo2hM/xrL19rW1oKHmBQN4AunWm5wTYTxVwBoL938SAxDwKrtdwN+ujOw3wqHW5zDIDoYkKh4iEmThCoTXdp3WafwH2n062jjgDo713sBpdObkbhKxUhn0qHy+OYrQBEH19cCp3dDP173RZHOJY6Hx6yFYCo9cQsxG+WGYzZXi1fLITaRsd33LQNQLI3dxIMMchu+odB759J71zVQnsX1B9fOEugxKZXviJAKFjcferDXT+t6KENgJjlBFsKYqDVIz7jMIBZL4El4pun06235VkbgIF4LsOAeKHS8zD2py6EJ/UYt8+qFgC2dDs+gOq1ZCC+kGCQmO3ofXwAG/UdiC9EGDSjV/mKdR/ARpmT8ZwQf2XVUi8HH8Dt+iZ7c0NgHNWr+hrrPoBbYlSWGK7aJr5IyAdwS+5kz8IoiA76ANQVsDwNdaT2S7aA59/i95hRUJelMTGI0DJxnI7Us2YZgCO1XwEAlt+YHXmI8fDFE/SDNgDlTZWW4g1HSicxBogW4BQABs5dGqZXjLSx1AJse+mqVgqXA6ASnrr4Nn2uFYCt8/71JXE3gE8nhukZI/HF/6ZbgKPdj9vHAMaLEyfoI60AKjtcGZlEtIRxaQtgxreXTlC7bJlNt4D++OIIgQ/JJtTwcC4FQMDrF4fplGx5TQNwtP93bxf028Qw7ZIV39IYkIznWCWhhoeVbwGPNDzt2ga/nhim4yrpmWoBjg/Aki1ARQinwpoCkOzJdYFw2alMl9OVaAGO5k8ycR+ApFC6gvkAdCkradcHICmUrmCmADi6BlRRolgI7Vhx79Mljh12TQGwffuxihKpdNhU3u0QVSUNU4XwAahIXD+sVwGUT5c0TgbnLHkVwFQqHTY8QxbNsHBd3KdJ3nwJaJuNUdnN3OzjSQDrXbxrFT6aYeEIK70yqSjisWyMyocsrDzeBEAUO3N+57hRwaMZ1rZeVQJ2WK39Iv+eBLDex74aiEiGIwFAi5skA2Mzsca43XsRgNQA3Jnhbga0bBiVgN2zMVo9ZGHUEuv97wSA/JqDFeoDJPNY6kKr4aGPjgyLI6A6nMWmsjEynADIQrEXAPNYsdgyuPIGu3wyPjTOCgMlgTvWnzKpVthohkUNvU9WCNlwAWD/lRg17GCIbQAImDudDm/wnK541onZyjYjEWrZWB9PY/8/l41RQ72/bQOANWdj1wuWjOek5usrp8uNQEUzPAJAx351XzZGo0bpq/xvHwDG4dSFsBBmwyPp3rh6utyogKIFhDScR25k17NSBhsB1B48pTb467QgIyBu/t8+AEKFKtuIyZ7cIAgnDaZqVccPNwsrmzd7ASy/+o2gRJMcwPYAl+fqhkdZZWc+soV2Uzj7ASiWXnbdR9Gsa4K7GoCYdhYKoa5m2PmqRdzNAPIE7pJ56XJNdTaREfcCaBK/HyMmrgQg+8JlVDgv/O86AKrid2RzR4ixtdFiE+P76T3hc422u96emwDkweiWvQElfp6DPz6QSwMU0yESMV6Y3hOe0GF7rU1XABCzHYATKgNu55XFNBP3aBLok2xn+DlNtm8z6zgAMc9fKgSHZKeaXZevbvlz613ndNV8Zvyy5b872r/cu+2PZgcwD0ZCtssRYkRmru8NlAJjAB7UJM4/gRI/eeXxVi1bmdXy7EQLEH39UK2V0WqZXK71d79TWWIOaBK/CNCz2c6dn2myX9WsnQDmCTxUKLSMy3Y3IsfR6YU+gN4EcL9GYX4GAi9lO+/5SmMajgDIg3mcA4FxGTeStTmMTucGiPEGE3ZrFOVvgEb+3VJ697tHW//SmE5N0zpaQH55xROTKv37cm2//hhxMM7EfQDu1SjIHDE+CC7defabJ7b+rjEdQ9M6AIhEhbveLBiTRJgsFEJz9bqdjuzC0wC9SoyHDHOsHmAJwDWA5olLs6UAfTETDf+qbkZPDF0A6uX2JoPG1t4eq6do3rDqBAChjJRzrTcktJZLRwA0+yaLChJzAKxeUVbHQ0Il880Q1hwAST+eWgI18x6vaqUwBaA/vnDVwtcvpP17VAvjxfDKACxfUyDpXOtFMc3kWRmA1XuCVDdczBTKS3HUAVi7J0jKt99LAlrNqwkAFvr/JnUvtAJBCYDF7me+WAhFVFZCrRTMK3GVACTjOXEw7oCZwvl9f3XVpAFY/DaAv/RQo9ZKA0jGc+KCJjNnozaFh5uZXkHEkQJg5XYU8cVQ1c0Ys4XxYjxDAJWuR9R+9S/g+Ws+hnWiLoDKATrhIWBCfLnjpIY5bPIANQFUlhxEzVc+FegvN8vXmqoAxK2ITCw+Qah8JYw/3ZQXf8MgLLqcwlLwqMnPD+aZKOEPuIoABuK5fQCL739Z+Y77x8VCKOG/5aqJX24BFq8gnmeiQb/Wqwu/EsMsgLKXm/gmuvmk/ZhmWsAUgUd94RtXeQxbgPDdZ8ZoKFQcX/sh4sZlYXNbKgMoi7zszQawuOaFxO0ls6quhZtbSnOlN1yKMGfWjyWrgA9AVilN4f4Hksmi5Awd7h8AAAAASUVORK5CYII\u003d"
   },
   "description": "Makes sure no tag or variable error goes unnoticed.\n\nThe Core Tag sends errors that happen in other Elevar Monitoring Tags and Elevar Monitoring Variables to the Elevar dashboard.",
-  "categories": ["UTILITY", "ANALYTICS", "TAG_MANAGEMENT"],
+  "categories": [
+    "UTILITY",
+    "ANALYTICS",
+    "TAG_MANAGEMENT"
+  ],
   "containerContexts": [
     "WEB"
   ]
@@ -49,6 +53,7 @@ const setInWindow = require("setInWindow");
 const sendPixel = require("sendPixel");
 const encodeUriComponent = require("encodeUriComponent");
 const getUrl = require("getUrl");
+const makeString = require("makeString");
 
 /**
  * This is required even though it wouldn't be used here
@@ -130,27 +135,27 @@ addEventCallback(function(containerId, _eventData) {
       const tagNames = getTagNames(tagsUsed);
 
       let url = "https://monitoring.getelevar.com/track.gif?ctid=" +
-          containerId +
+          encodeUriComponent(makeString(containerId)) +
           "&idx=" +
-          index +
+          encodeUriComponent(makeString(index)) +
           "&event_name=" +
-          encodeUriComponent(eventName) +
+          encodeUriComponent(makeString(eventName)) +
           "&variable_name=" +
-          encodeUriComponent(errorEvent.variableName) +
+          encodeUriComponent(makeString(errorEvent.variableName)) +
           "&channels=" +
-          encodeUriComponent(channels) +
+          encodeUriComponent(makeString(channels)) +
           "&tag_names=" +
-          encodeUriComponent(tagNames) +
+          encodeUriComponent(makeString(tagNames)) +
           "&dlKey=" +
-          errorEvent.dataLayerKey +
+          encodeUriComponent(makeString(errorEvent.dataLayerKey)) +
           "&dlValue=" +
-          encodeUriComponent(errorEvent.error.value) +
+          encodeUriComponent(makeString(errorEvent.error.value)) +
           "&cond=" +
-          errorEvent.error.condition +
+          encodeUriComponent(makeString(errorEvent.error.condition)) +
           "&condValue=" +
-          encodeUriComponent(errorEvent.error.conditionValue) +
+          encodeUriComponent(makeString(errorEvent.error.conditionValue)) +
           "&url=" +
-          encodeUriComponent(PAGE_URL);
+          encodeUriComponent(makeString(PAGE_URL));
 
       log("pixel url = ", url);
       if (!data.debugMode) {
@@ -471,6 +476,26 @@ scenarios:
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('sendPixel').wasNotCalled();
     assertThat(sentUrls.length === 0).isTrue();
+- name: PIXEL // No event matching
+  code: |-
+    elevar_gtm_errors = [{
+      eventId: 100,
+      dataLayerKey: 'key',
+      variableName: 'dlv - Variable 1',
+      error: {
+        message: 'message',
+        value: 'val',
+        condition: 'condition',
+        conditionValue: 'conditionValue'
+      }
+    }];
+
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(sentUrls.length === 1).isTrue();
+    assertThat(getQueryParams(sentUrls[0], 'event_name')).isEqualTo('false');
 - name: PIXEL // No tags data match
   code: |-
     elevar_gtm_errors = [{
@@ -494,14 +519,14 @@ scenarios:
     assertThat(getQueryParams(sentUrls[0], 'channels')).isEqualTo('');
     assertThat(getQueryParams(sentUrls[0], 'variable_name')).isEqualTo('dlv%20-%20Variable%201');
 - name: PIXEL // Erroring variable in multiple tags
-  code: "elevar_gtm_errors = [{\n  eventId: 7,\n  dataLayerKey: 'key',\n  variableName:\
-    \ 'dlv - Variable 1',\n  error: {\n    message: 'message',\n    value: 'val',\n\
-    \    condition: 'condition',\n    conditionValue: 'conditionValue'\n  }\n}];\n\
-    \nelevar_gtm_tag_info = [{\n\teventId: 7,\n  \tchannel: 'facebook',\n\ttagName:\
-    \ \"Facebook - Initiate Checkout\",\n  \tvariables: ['dlv - Variable 1', 'dlv\
-    \ - Variable 2'],\n}, {\n\teventId: 7,\n    channel: 'facebook',\n  \ttagName:\
-    \ \"Facebook - Conversion\",\n   \tvariables: ['dlv - Variable 1', 'dlv - Variable\
-    \ 2'],\n}];\n\n// Call runCode to run the template's code.\nrunCode(mockData);\n\
+  code: "elevar_gtm_errors = [{\n  eventId: 7,\n  dataLayerKey: 'key.item.0.id',\n\
+    \  variableName: 'dlv - Variable 1',\n  error: {\n    message: 'message',\n  \
+    \  value: 'val',\n    condition: 'condition',\n    conditionValue: 'conditionValue'\n\
+    \  }\n}];\n\nelevar_gtm_tag_info = [{\n\teventId: 7,\n  \tchannel: 'facebook',\n\
+    \ttagName: \"Facebook - Initiate Checkout\",\n  \tvariables: ['dlv - Variable\
+    \ 1', 'dlv - Variable 2'],\n}, {\n\teventId: 7,\n    channel: 'facebook',\n  \t\
+    tagName: \"Facebook - Conversion\",\n   \tvariables: ['dlv - Variable 1', 'dlv\
+    \ - Variable 2'],\n}];\n\n// Call runCode to run the template's code.\nrunCode(mockData);\n\
     \nassertApi('gtmOnSuccess').wasCalled();\nassertThat(getQueryParams(sentUrls[0],\
     \ 'channels')).isEqualTo('facebook');\nassertThat(\n  getQueryParams(sentUrls[0],\
     \ 'tag_names')\n).isEqualTo('Facebook%20-%20Initiate%20Checkout%2CFacebook%20-%20Conversion');\n\
@@ -548,6 +573,94 @@ scenarios:
     assertThat(getQueryParams(sentUrls[0], 'dlValue')).isEqualTo('val');
     assertThat(getQueryParams(sentUrls[0], 'cond')).isEqualTo('condition');
     assertThat(getQueryParams(sentUrls[0], 'condValue')).isEqualTo('conditionValue');
+- name: PIXEL // Variable error contains undefined
+  code: |-
+    elevar_gtm_errors = [{
+      eventId: 7,
+      dataLayerKey: 'key',
+      variableName: 'variable name',
+      error: {
+        condition: 'condition',
+      }
+    }];
+
+    elevar_gtm_tag_info = undefined;
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(sentUrls.length === 1).isTrue();
+    assertThat(getQueryParams(sentUrls[0], 'dlValue')).isEqualTo("undefined");
+- name: PIXEL // Variable error contains object
+  code: |-
+    elevar_gtm_errors = [{
+      eventId: 7,
+      dataLayerKey: 'key',
+      variableName: 'variable name',
+      error: {
+        message: 'dlvkey=[Object object] condition conditionValue',
+        value: { object: 'ok' },
+        condition: 'condition',
+        conditionValue: false
+      }
+    }];
+
+    elevar_gtm_tag_info = undefined;
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(sentUrls.length === 1).isTrue();
+    assertThat(getQueryParams(sentUrls[0], 'dlValue')).isEqualTo("%5Bobject%20Object%5D");
+- name: PIXEL // Variable error contains array
+  code: |-
+    elevar_gtm_errors = [{
+      eventId: 7,
+      dataLayerKey: 'key',
+      variableName: 'variable name',
+      error: {
+        message: 'dlvkey=arr condition conditionValue',
+        value: ['cool', 'ok'],
+        condition: 'condition',
+        conditionValue: false
+      }
+    }];
+
+    elevar_gtm_tag_info = undefined;
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(sentUrls.length === 1).isTrue();
+    assertThat(getQueryParams(sentUrls[0], 'dlValue')).isEqualTo("cool%2Cok");
+- name: PIXEL // Variable name is undefined
+  code: |-
+    elevar_gtm_errors = [{
+      eventId: 7,
+      dataLayerKey: 'key',
+      error: {
+        message: 'message',
+        value: 'val',
+        condition: 'condition',
+        conditionValue: 'condVal'
+      }
+    }];
+
+    elevar_gtm_tag_info = undefined;
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(sentUrls.length === 1).isTrue();
+    assertThat(getQueryParams(sentUrls[0], 'variable_name')).isEqualTo("undefined");
 - name: GENERAL // Debug mode
   code: |-
     mockData.debugMode = true;


### PR DESCRIPTION
FIx issue on trysnow.com where the newest update stopped errors from being reported.

- make sure `encodeUriComponent` always receives a string as input by wrapping the items inside with `makeString`

Add tests to test:
- Variable error values being undefined
- Variable error values containing objects
- Variable error values containing arrays
- Variable name being undefined
- No event name matching eventId

---

NOTE: If the erroring variable contains an array ([1, 2, 3]) the array will be sent as string of comma separated values ("1,2,3") which might cause some issues if the array is very long in the URL length. I didn't resolve this here because I didn't know what to send instead.